### PR TITLE
Implement dark theme toggle functionality

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { MenuItem, CartItem } from './types';
 import { fetchCart, addToCartApi, removeFromCartApi, updateCartItem } from './api';
 import { LiveAssistant } from './components/LiveAssistant';
 import { useToast } from './components/Toast';
+import { ThemeToggle } from './components/ThemeToggle';
 
 // Code-split pages
 const Home = lazy(() => import('./pages/Home'));
@@ -67,6 +68,7 @@ const Navbar: React.FC<{ cartCount: number }> = ({ cartCount }) => {
                 {link.name}
               </Link>
             ))}
+            <ThemeToggle />
             <Link to="/checkout" className="relative bg-primary text-white p-2.5 rounded-full hover:shadow-lg hover:shadow-primary/30 transition-all" aria-label={`Shopping cart${cartCount > 0 ? `, ${cartCount} items` : ', empty'}`}>
               <span className="material-icons" aria-hidden="true">shopping_cart</span>
               {cartCount > 0 && (
@@ -103,6 +105,10 @@ const Navbar: React.FC<{ cartCount: number }> = ({ cartCount }) => {
               {link.name}
             </Link>
           ))}
+          <div className="flex items-center gap-2 py-2">
+            <span className="font-medium">Theme</span>
+            <ThemeToggle />
+          </div>
           <Link
             to="/checkout"
             className="flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg"

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+
+export const ThemeToggle: React.FC = () => {
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    // Check localStorage for saved theme preference
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      return savedTheme === 'dark';
+    }
+    // Default to system preference
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    // Apply theme to document
+    if (isDark) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDark]);
+
+  const toggleTheme = () => {
+    setIsDark(!isDark);
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-full hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors"
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {isDark ? (
+        <span className="material-icons text-yellow-400" aria-hidden="true">light_mode</span>
+      ) : (
+        <span className="material-icons text-stone-600" aria-hidden="true">dark_mode</span>
+      )}
+    </button>
+  );
+};


### PR DESCRIPTION
This PR implements a dark theme toggle for the Dakshin Delights website.

## Changes
- Created ThemeToggle component with localStorage persistence
- Added theme toggle to desktop and mobile navigation
- Support system preference detection as default
- Use sun/moon icons with accessibility labels
- Leverage existing TailwindCSS dark mode configuration

Fixes #1

Generated with [Claude Code](https://claude.ai/code)