### PR TITLE
Fix Tailwind v4 custom theme colors not applying

### DIFF
--- a/index.css
+++ b/index.css
@@ -2,6 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Tailwind v4 CSS-first theme configuration */
+@plugin "@tailwindcss/forms";
+
+@variant dark (&:where(.dark, .dark *));
+
+@theme {
+  --color-primary: #ec5b13;
+  --color-background-light: #f8f6f6;
+  --color-background-dark: #221610;
+  --color-accent-gold: #FFB800;
+  --color-deep-orange: #D34700;
+  --color-cream: #FFF9E6;
+  --font-family-display: 'Work Sans', sans-serif;
+}
+
 /* Focus indicators for keyboard navigation */
 *:focus-visible {
   outline: 2px solid #ec5b13;


### PR DESCRIPTION
## Summary

- Tailwind CSS v4's `@tailwindcss/postcss` plugin does not read `tailwind.config.js` — it requires CSS-first configuration via CSS directives
- All custom brand colours (`primary`, `background-dark`, `background-light`, `accent-gold`, `deep-orange`) were silently unresolved, making every page render without any styling (no orange, no dark backgrounds, no brand theme)
- Fixed by adding `@plugin`, `@variant dark`, and `@theme` directives to `index.css`

## Root Cause

`tailwind.config.js` was defined correctly for Tailwind v3, but the project uses **Tailwind v4** (`@tailwindcss/postcss@4.1.18`). In v4, the PostCSS plugin completely ignores `tailwind.config.js` and instead expects all theme configuration inline in CSS using `@theme {}`.

## Changes

**`index.css`** — added 15 lines of Tailwind v4 CSS-first config:

```css
@plugin "@tailwindcss/forms";

@variant dark (&:where(.dark, .dark *));

@theme {
  --color-primary: #ec5b13;
  --color-background-light: #f8f6f6;
  --color-background-dark: #221610;
  --color-accent-gold: #FFB800;
  --color-deep-orange: #D34700;
  --color-cream: #FFF9E6;
  --font-family-display: 'Work Sans', sans-serif;
}
```

## Impact

| Before | After |
|--------|-------|
| CSS bundle: 11.25 kB | CSS bundle: 23.07 kB (gzip: 4.56 kB) |
| 0 custom color classes generated | `bg-primary`, `text-primary`, `dark:bg-background-dark`, etc. all generated |
| Home page: unstyled (white/grey) | Home page: full brand theme applied |

## Test Plan

- [x] Production build passes (`npm run build`)
- [x] `bg-primary`, `text-primary`, `dark:bg-background-dark` confirmed in generated CSS
- [x] `--color-primary` CSS custom property defined on `:root`
- [x] Dark mode variant uses `.dark` class selector strategy
- [ ] Visual check: home page hero, navbar, buttons display orange brand colour
- [ ] Visual check: dark mode toggle switches between light/dark backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)